### PR TITLE
Bump to v0.2.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-safe"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 description = "Sponge API for Field Elements"
 categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
### Added

- Add authenticated encryption and decryption [#6]

### Changed

- Let `Sponge::start` take the io-pattern as `impl Into<Vec<Call>>` [#4]
