### PR TITLE
Bump to v0.2.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-safe"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 description = "Sponge API for Field Elements"
 categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,6 @@ mod tests {
         assert!(validate_io_pattern(&iopattern).is_err());
 
         let iopattern =
-            // vec![Call::Absorb(3), Call::Absorb(2147483648), Call::Squeeze(1)];
             vec![Call::Absorb(3), Call::Absorb(1 << 31), Call::Squeeze(1)];
         assert!(validate_io_pattern(&iopattern).is_err());
     }


### PR DESCRIPTION
### Added

- Add authenticated encryption and decryption [#6]
- Add check for `cipher.len == message.len + 1` in `encrypt` and `decrypt` [#9]
- Add check for max squeeze and absorb len [#17]

### Changed

- Let `Sponge::start` take the io-pattern as `impl Into<Vec<Call>>` [#4]
- Change `nonce` to be `&T` instead of `T` in `encrypt` and `decrypt` [#9]
- Improve crate documentation [#13]
- Rename `Encryption::assert_equal` to `Encryption::is_equal` [#15]

This release of a rc outside of the release schedule is needed for the poseidon audit.