### PR TITLE
Bump to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-03-27
+
 ### Added
 
 - Add authenticated encryption and decryption [#6]
@@ -43,4 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/safe/compare/v0.1.0...HEAD
+[0.2.0]: https://github.com/dusk-network/safe/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/safe/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-safe"
-version = "0.2.0-rc.0"
+version = "0.2.0"
 description = "Sponge API for Field Elements"
 categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.2.0] - 2024-03-27

### Added

- Add authenticated encryption and decryption [#6]
- Add check for `cipher.len == message.len + 1` in `encrypt` and `decrypt` [#9]
- Add check for max squeeze and absorb len [#17]

### Changed

- Let `Sponge::start` take the io-pattern as `impl Into<Vec<Call>>` [#4]
- Change `nonce` to be `&T` instead of `T` in `encrypt` and `decrypt` [#9]
- Improve crate documentation [#13]
- Rename `Encryption::assert_equal` to `Encryption::is_equal` [#15]

[0.2.0]: https://github.com/dusk-network/safe/compare/v0.1.0...v0.2.0
