### PR TITLE
Bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-05-08
+
 ### Changed
 
 - Omit unnecessary check on `message_len` in `decrypt` [#21]
@@ -49,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/safe/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/safe/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/safe/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/dusk-network/safe/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/dusk-network/safe/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/safe/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-safe"
-version = "0.2.0"
+version = "0.2.1"
 description = "Sponge API for Field Elements"
 categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.2.1] - 2024-05-08

### Changed

- Omit unnecessary check on `message_len` in `decrypt` [#21]

[0.2.1]: https://github.com/dusk-network/safe/compare/v0.2.0...v0.2.1
