### PR TITLE
Changed rust toolchain version to nightly-2023-11-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update dependency `dusk-bls12_381` to 0.14
 - Update dependency `dusk-jubjub` to 0.15
+- Change rust toolchain version to `nightly-2023-11-10` (1.75.0) [#26]
 
 ## [0.2.1] - 2024-05-08
 
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add documentation
 
 <!-- ISSUES -->
+[#26]: https://github.com/dusk-network/safe/issues/26
 [#21]: https://github.com/dusk-network/safe/issues/21
 [#17]: https://github.com/dusk-network/safe/issues/17
 [#15]: https://github.com/dusk-network/safe/issues/15

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-05-22"
+channel = "nightly-2023-11-10"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
For https://github.com/dusk-network/safe/issues/26

Most dusk crates use the rust nightly-2023-11-10.

| Crate | Rust Toolchain Version |
-------|------------------------|
| `dusk-safe` | 1.71.0 nightly (2023-05-22) |
| `kadcast` | 1.71.0 nightly (2023-05-22) |
| `dusk-plonk` | 1.75.0 nightly (2023-11-10) |
| `rusk` | 1.75.0 nightly (2023-11-10) |
| `phoenix` | 1.75.0 nightly (2023-11-10) |
| `dusk-poseidon` | 1.75.0 nightly (2023-11-10) |
| `jubjub-schnorr` | 1.75.0 nightly (2023-11-10) |
| `jubjub-elgamal` | 1.75.0 nightly (2023-11-10) |
| `piecrust` | 1.75.0 nightly (2023-11-10) |
| `bls-12_381` | 1.75.0 nightly (2023-10-29) |
| `dusk-jubjub` | latest nightly |
| `dusk-bls12_381` | latest nightly |
| `dusk-merkle` | latest nightly |

This PR changes the rust toolchain version to nightly-2023-11-10.
