### PR TITLE
Release `0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-02-06
+
 ### Changed
 
 - Update dependency `dusk-bls12_381` to 0.14
@@ -58,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/safe/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/safe/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/dusk-network/safe/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/safe/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/dusk-network/safe/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/dusk-network/safe/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/safe/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-safe"
-version = "0.2.1"
+version = "0.3.0"
 description = "Sponge API for Field Elements"
 categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]


### PR DESCRIPTION
## [0.3.0](https://github.com/dusk-network/safe/compare/v0.2.1...v0.3.0) - 2025-02-06

### Changed

- Update dependency `dusk-bls12_381` to 0.14
- Update dependency `dusk-jubjub` to 0.15
- Change rust toolchain version to `nightly-2023-11-10` (1.75.0) [#26]