### PR TITLE
AI-friendliness pass

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -7,19 +7,20 @@ on:
 name: Continuous integration
 
 jobs:
-  code_analysis:
-    name: Code Analysis
-    uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
+  code-quality:
+    name: Code quality
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
     with:
-      clippy_default: false
-      clippy_args: --features=encryption -- -D warnings
+      make_target: cq
 
-  dusk_analyzer:
-    name: Dusk Analyzer
-    uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
-
-  test_nightly:
+  test:
     name: Run tests
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
     with:
-      test_flags: --features=encryption
+      make_target: test
+
+  no-std:
+    name: Run no-std tests
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
+    with:
+      make_target: no-std

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Safe
+
+Sponge API framework for field elements with IO-pattern validation. Underpins Poseidon hashing and authenticated encryption across the Dusk network. Single `no_std` crate with `alloc`.
+
+## Repository Map
+
+```
+safe/
+├── src/
+│   ├── lib.rs          # Call enum, IO-pattern encoding and validation
+│   ├── sponge.rs       # Safe<T, W> trait and Sponge<S, T, W> struct
+│   ├── encryption.rs   # encrypt()/decrypt() via sponge (encryption feature)
+│   └── error.rs        # Error types
+├── tests/              # Integration tests
+├── Cargo.toml
+└── Makefile
+```
+
+## Commands
+
+Run `make help` to see all available targets.
+
+## Feature Flags
+
+| Feature      | Description                          | Default |
+|--------------|--------------------------------------|---------|
+| `encryption` | Authenticated encrypt/decrypt functions | No      |
+
+## Architecture
+
+### Sponge API
+
+The core abstraction is the **SAFE (Sponge API for Field Elements)** framework:
+
+- **`Safe<T, W>` trait** — defines the sponge permutation, tag creation, and field addition. Parameterized by element type `T` and state width `W`. The trait's `add` method enables usage within zero-knowledge circuits.
+- **`Sponge<S, T, W>` struct** — stateful sponge that enforces an IO-pattern (sequence of `Absorb(n)` / `Squeeze(n)` calls). Violations zeroize the state and return an error.
+- **IO-pattern validation** — patterns are encoded into a tag input that binds the sponge instance to its expected call sequence and domain separator. Consecutive same-type calls are aggregated.
+
+### Encryption
+
+Behind the `encryption` feature:
+
+- **`Encryption<T, W>` trait** — extends `Safe` with subtraction and equality (also circuit-compatible).
+- **`encrypt` / `decrypt`** — authenticated encryption using the sponge. Absorbs a shared secret and nonce, then XORs the message with squeezed keystream. A final squeeze element serves as an authentication tag.
+
+### Key Dependencies
+
+- `zeroize` — memory safety for sponge state on drop and on error
+
+## Conventions
+
+- **`no_std`** with `alloc`. Do not add `std` dependencies.
+- **`zeroize`** — sponge state is zeroized on drop and on any IO-pattern violation.
+- **No PLONK dependency** — debug mode tests are fine here.
+- **Edition 2021**.
+
+## Elevated Care Zones
+
+This is a **cryptographic primitive** — bugs here propagate to all Poseidon hash and encryption operations across the Dusk stack. Treat every change as elevated care:
+
+- Run the full test suite with `make test`
+- Verify both `--features=encryption` and `--no-default-features` configurations
+- Do not introduce branches or early returns on secret data
+- Verify edge cases (zero-length patterns, boundary lengths)
+
+## Change Propagation
+
+| Changed | Also verify |
+|---------|-------------|
+| `safe`  | `Poseidon252`, then its dependents (`merkle`, `phoenix`, `rusk`) |
+
+## Git Conventions
+
+- Default branch: `main`
+- License: MPL-2.0
+
+### Commit messages
+
+Format: `<Description>` — imperative mood, capitalize first word. Single-crate repo, no scope prefix needed.
+
+Cross-cutting prefixes for non-code changes: `ci`, `docs`, `chore`.
+
+Examples:
+- `Add IO-pattern length validation`
+- `Fix sponge state leak on absorb error`
+- `ci: Update workflow to use Makefile targets`
+
+### Changelog
+
+Maintain `CHANGELOG.md` with entries under `[Unreleased]` using [keep-a-changelog](https://keepachangelog.com/) format. If a change traces to a GitHub issue, reference it as a link: `[#42](https://github.com/dusk-network/safe/issues/42)`. Only link to GitHub issues — do not reference any other tracking system.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+fmt: ## Format code
+	@rustup component add --toolchain nightly rustfmt 2>/dev/null || true
+	@cargo +nightly fmt --all $(if $(CHECK),-- --check,)
+
+clippy: ## Run clippy
+	@cargo clippy --features=encryption -- -D warnings
+
+cq: ## Run code quality checks (formatting + clippy)
+	@$(MAKE) fmt CHECK=1
+	@$(MAKE) clippy
+
+check: ## Type-check
+	@cargo check --features=encryption
+
+test: ## Run tests
+	@cargo test --features=encryption
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@rustup target add thumbv6m-none-eabi 2>/dev/null || true
+	@cargo build --no-default-features --target thumbv6m-none-eabi
+
+doc: ## Generate docs
+	@cargo doc --no-deps --features=encryption
+
+clean: ## Clean build artifacts
+	@cargo clean
+
+.PHONY: help fmt clippy cq check test no-std doc clean

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,6 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+use_field_init_shorthand = true
 wrap_comments = true
 max_width = 80

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -6,8 +6,9 @@
 
 use alloc::vec::Vec;
 
-use crate::{Call, Error, Safe, Sponge};
 use zeroize::Zeroize;
+
+use crate::{Call, Error, Safe, Sponge};
 
 /// Trait defining encryption operations along with the [`Safe`] trait,
 /// facilitating encryption using the SAFE framework.

--- a/src/sponge.rs
+++ b/src/sponge.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use alloc::vec::Vec;
+
 use zeroize::Zeroize;
 
 use crate::{Call, Error, tag_input};


### PR DESCRIPTION
## Summary

Add Makefile, update CI to use Makefile targets with inline jobs on `core` runners, update rustfmt.toml with import grouping and field init shorthand, apply formatting, and add AGENTS.md with CLAUDE.md as a symlink. Fixes a pre-existing broken doc link to `Sponge::absorb` in `error.rs`.