### PR TITLE
Update to edition 2024 with MSRV 1.85 and stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ categories = ["algorithms", "cryptography", "no-std"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]
 
 repository = "https://github.com/dusk-network/safe"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "MPL-2.0"
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-11-10"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,8 @@ pub enum Error {
     InvalidIOPattern,
 
     /// This error occurs when the input elements provided to the
-    /// [`Sponge::absorb`] are less than the amount that should be absorbed.
+    /// [`Sponge::absorb`](crate::Sponge::absorb) are less than the amount
+    /// that should be absorbed.
     TooFewInputElements,
 
     /// This error indicates a failure during the encryption process.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use sponge::{Safe, Sponge};
 #[cfg(feature = "encryption")]
 mod encryption;
 #[cfg(feature = "encryption")]
-pub use encryption::{decrypt, encrypt, Encryption};
+pub use encryption::{Encryption, decrypt, encrypt};
 
 /// Enum to encode the calls to [`Sponge::absorb`] and [`Sponge::squeeze`] that
 /// make the IO-pattern.

--- a/src/sponge.rs
+++ b/src/sponge.rs
@@ -7,7 +7,7 @@
 use alloc::vec::Vec;
 use zeroize::Zeroize;
 
-use crate::{tag_input, Call, Error};
+use crate::{Call, Error, tag_input};
 
 /// This trait defines the behavior of a sponge algorithm.
 ///

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -7,11 +7,11 @@
 #![cfg(feature = "encryption")]
 
 use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::{JubJubExtended, JubJubScalar, GENERATOR_EXTENDED};
-use dusk_safe::{decrypt, encrypt, Encryption, Error, Safe};
+use dusk_jubjub::{GENERATOR_EXTENDED, JubJubExtended, JubJubScalar};
+use dusk_safe::{Encryption, Error, Safe, decrypt, encrypt};
 use ff::Field;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 const W: usize = 7;
 const DOMAIN: u64 = 1 << 31;


### PR DESCRIPTION
Align safe with the rest of the dusk repos by moving from edition 2021 with nightly-2023-11-10 to edition 2024 with stable toolchain and MSRV 1.85. Fix a broken intra-doc link in error.rs exposed by the edition migration.